### PR TITLE
Behavior that writes npmrc file

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/npmpackage/NpmConfig.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/NpmConfig.scala
@@ -1,0 +1,46 @@
+package io.chrisdavenport.npmpackage
+
+import java.io.File
+import java.nio.file.Files
+import sbt._
+import java.nio.charset.StandardCharsets
+
+object NpmConfig {
+  // @myscope:registry=https://mycustomregistry.example.org/:_authToken=\\${NPM_TOKEN}
+  private val defaultRegistry = "//registry.npmjs.org/"
+
+  def writeNpmrc(
+    targetDir: File,
+    scope: Option[String],
+    customRegistry: Option[String],
+    environmentVariableForAuth: String,
+    log: Logger,
+  ): File = {
+    val targetFile = targetDir / ".npmrc"
+
+    if (Files.exists(targetDir.toPath())) ()
+    else Files.createDirectories(targetDir.toPath())
+    Files.deleteIfExists(targetFile.toPath())
+
+    val output = fileContent(scope, customRegistry, environmentVariableForAuth)
+
+    Files.write(targetFile.toPath(), output.getBytes(StandardCharsets.UTF_8))
+    
+    log.info(s"Wrote $targetFile with content: $output")
+
+    targetFile
+  }
+
+  def fileContent(
+    scope: Option[String],
+    customRegistry: Option[String],
+    environmentVariableForAuth: String
+  ): String = {
+    val scopeComponent = scope.fold("")(s => s"@$s:")
+    val registryComponent = customRegistry.fold(defaultRegistry)(reg => s"registry=$reg")
+    val authComponent = ":_authToken=${" ++ environmentVariableForAuth ++ "}"
+    
+    scopeComponent ++ registryComponent ++ authComponent
+  }
+
+}

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -148,6 +148,15 @@ object NpmPackagePlugin extends AutoPlugin {
     val npmPackageKeywords: SettingKey[Seq[String]] =
       settingKey("Keywords to place in the npm package")
 
+    val npmPackageNpmrcRegistry: SettingKey[Option[String]] =
+      settingKey("npm registry to publish to, defaults to registry.npmjs.org")
+
+    val npmPackageNpmrcScope: SettingKey[Option[String]] =
+      settingKey("Scope to use if you want a limited scoep in your npm repository")
+
+    val npmPackageNpmrcAuthEnvironmentalVariable: SettingKey[String] = 
+      settingKey("Environmental Variable that holds auth information")
+
 
     val npmPackage = taskKey[Unit]("Creates all files and direcories for the npm package")
 
@@ -156,6 +165,7 @@ object NpmPackagePlugin extends AutoPlugin {
     val npmPackageWriteREADME = taskKey[File]("Write README to the npm package")
     val npmPackageInstall = taskKey[File]("Install Deps for npm/yarn for the npm package")
     val npmPackagePublish = taskKey[File]("Publish for npm/yarn for the npm package")
+    val npmPackageNpmrc = taskKey[File]("Write Npmrc File")
 
   }
   import autoImport._
@@ -186,6 +196,9 @@ object NpmPackagePlugin extends AutoPlugin {
     npmPackageNpmExtraArgs := Seq.empty,
     npmPackageYarnExtraArgs := Seq.empty,
     npmPackageKeywords := Seq.empty,
+    npmPackageNpmrcRegistry := None,
+    npmPackageNpmrcScope := None,
+    npmPackageNpmrcAuthEnvironmentalVariable := "NPM_TOKEN",
     npmPackageREADME := {
       val path = file("README.md")
       if (java.nio.file.Files.exists(path.toPath())) Option(path)
@@ -299,6 +312,16 @@ object NpmPackagePlugin extends AutoPlugin {
           npmPackageYarnExtraArgs.value,
         )
         output
+      },
+
+      npmPackageNpmrc := {
+        NpmConfig.writeNpmrc(
+          npmPackageOutputDirectory.value,
+          npmPackageNpmrcScope.value,
+          npmPackageNpmrcRegistry.value,
+          npmPackageNpmrcAuthEnvironmentalVariable.value,
+          streams.value.log
+        )
       },
 
       npmPackage := {

--- a/core/src/sbt-test/sbt-npm-package/minimal-example/test
+++ b/core/src/sbt-test/sbt-npm-package/minimal-example/test
@@ -1,6 +1,5 @@
 > clean
 
 # Check Node Output
-> npmPackagePackageJson
-> npmPackageOutputJS
+> npmPackageNpmrc 
 > npmPackage


### PR DESCRIPTION
To be used in custom workflows to allow automatic ci. Not tied into any other tasks and must be run independently.