### PR TITLE
Set hashbang using `jsHeader` config

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -215,7 +215,14 @@ object NpmPackagePlugin extends AutoPlugin {
       if (java.nio.file.Files.exists(path.toPath())) Option(path)
       else Option.empty[File]
     },
-    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
+    scalaJSLinkerConfig := {
+      val c = scalaJSLinkerConfig.value
+      val hashbang = if (npmPackageBinaryEnable.value)
+        "#!/usr/bin/env node\n"
+      else
+        ""
+      c.withModuleKind(ModuleKind.CommonJSModule).withJSHeader(s"${hashbang}${c.jsHeader}")
+    },
   ) ++
     inConfig(Compile)(perConfigSettings) ++
     inConfig(Test)(perConfigSettings)

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -10,6 +10,7 @@ import org.scalajs.sbtplugin.Stage
 import org.scalajs.sbtplugin.Stage.FastOpt
 import org.scalajs.sbtplugin.Stage.FullOpt
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 // import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport._
 
 object NpmPackagePlugin extends AutoPlugin {
@@ -269,8 +270,7 @@ object NpmPackagePlugin extends AutoPlugin {
           if (Files.exists(targetDir.toPath())) ()
           else Files.createDirectories(targetDir.toPath())
 
-          if (Files.exists(targetPath)) Files.delete(targetPath) else ()
-          Files.copy(from, targetPath)
+          Files.copy(from, targetPath, StandardCopyOption.REPLACE_EXISTING)
           streams.value.log.info(s"Wrote $from to $targetPath")
           target
         }

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -270,10 +270,7 @@ object NpmPackagePlugin extends AutoPlugin {
           else Files.createDirectories(targetDir.toPath())
 
           if (Files.exists(targetPath)) Files.delete(targetPath) else ()
-          val fromString = new String (Files.readAllBytes(from))
-          val binaryString = if (npmPackageBinaryEnable.value) "#!/usr/bin/env node\n" else ""
-          val finalString = binaryString ++ fromString
-          Files.write(targetPath, finalString.getBytes())
+          Files.copy(from, targetPath)
           streams.value.log.info(s"Wrote $from to $targetPath")
           target
         }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("io.chrisdavenport" % "sbt-davenverse" % "0.1.1")
+addSbtPlugin("io.chrisdavenport" % "sbt-davenverse" % "0.1.4")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")


### PR DESCRIPTION
Using the `jsHeader` config prevents the sourcemaps from being corrupted.