### PR TITLE
Set `"type"` for commonjs/esmodule in package.json

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/npmpackage/PackageFile.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/PackageFile.scala
@@ -8,6 +8,48 @@ import java.nio.file.Files
 
 object PackageFile {
 
+  @deprecated("Use `writePackageJson` with `type` instead", "0.1.1")
+  def writePackageJson(
+    targetDir: File,
+    name: String,
+    version: String,
+    description: String,
+    repository: Option[String],
+    author: String,
+    license: Option[String],
+    keywords: List[String],
+    filename: String,
+    npmDependencies: Seq[(String, String)],
+    npmDevDependencies: Seq[(String, String)],
+    npmResolutions: Map[String, String],
+    additionalNpmConfig: Map[String, Json],
+    enableBinary: Boolean,
+    binaryArtifacts: Seq[(String, String)],
+    fullClasspath: Seq[Attributed[File]],
+    configuration: Configuration,
+    streams: Keys.TaskStreams
+  ): File = writePackageJson(
+    targetDir,
+    name,
+    version,
+    description,
+    repository,
+    author,
+    license,
+    keywords,
+    filename,
+    npmDependencies,
+    npmDevDependencies,
+    npmResolutions,
+    additionalNpmConfig,
+    enableBinary,
+    binaryArtifacts,
+    "commonjs",
+    fullClasspath,
+    configuration,
+    streams
+  )
+
   def writePackageJson(
     targetDir: File,
     name: String,

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/PackageFile.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/PackageFile.scala
@@ -24,6 +24,7 @@ object PackageFile {
     additionalNpmConfig: Map[String, Json],
     enableBinary: Boolean,
     binaryArtifacts: Seq[(String, String)],
+    `type`: String,
     fullClasspath: Seq[Attributed[File]],
     configuration: Configuration,
     streams: Keys.TaskStreams
@@ -47,6 +48,7 @@ object PackageFile {
       additionalNpmConfig,
       enableBinary,
       binaryArtifacts,
+      `type`,
       fullClasspath,
       configuration
     )
@@ -71,6 +73,7 @@ object PackageFile {
     additionalNpmConfig: Map[String, Json],
     enableBinary: Boolean,
     binaryArtifacts: Seq[(String, String)],
+    `type`: String,
     fullClasspath: Seq[Attributed[File]],
     currentConfiguration: Configuration,
   ): Unit = {
@@ -91,6 +94,7 @@ object PackageFile {
         additionalNpmConfig,
         enableBinary,
         binaryArtifacts,
+        `type`,
         fullClasspath,
         currentConfiguration
       )
@@ -115,6 +119,7 @@ object PackageFile {
     additionalNpmConfig: Map[String, Json],
     enableBinary: Boolean,
     binaryArtifacts: Seq[(String, String)],
+    `type`: String,
     fullClasspath: Seq[Attributed[File]],
     currentConfiguration: Configuration,
   ): Json = {
@@ -145,6 +150,7 @@ object PackageFile {
           "name" -> name.asJson,
           "description" -> description.asJson,
           "version" -> version.asJson,
+          "type" -> `type`.asJson,
           "repository" -> repository.map(repo => Json.obj(
             "type" -> "git".asJson,
             "url" -> repo.asJson,

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -169,7 +169,7 @@ object NpmPackagePlugin extends AutoPlugin {
       settingKey("The name of the binary executable - defaults to project name")
 
     val npmPackageType: SettingKey[String] = 
-      settingKey("The type of the package - defaults to 'commonjs' for ModuleKind.CommonJSModule and 'module' for ModuleKind.ESModule")
+      settingKey("The type of the package - defaults to 'commonjs' for ModuleKind.CommonJSModule or ModuleKind.NoModule, and 'module' for ModuleKind.ESModule")
 
     val npmPackage = taskKey[Unit]("Creates all files and direcories for the npm package")
 

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -168,6 +168,9 @@ object NpmPackagePlugin extends AutoPlugin {
     val npmPackageBinaries: SettingKey[Seq[(String, String)]] =
       settingKey("The name of the binary executable - defaults to project name")
 
+    val npmPackageType: SettingKey[String] = 
+      settingKey("The type of the package - defaults to 'commonjs' for ModuleKind.CommonJSModule and 'module' for ModuleKind.ESModule")
+
     val npmPackage = taskKey[Unit]("Creates all files and direcories for the npm package")
 
     val npmPackageOutputJS = taskKey[File]("Write JS to output directory")
@@ -212,6 +215,10 @@ object NpmPackagePlugin extends AutoPlugin {
     npmPackageNpmrcAuthEnvironmentalVariable := "NPM_TOKEN",
     npmPackageBinaryEnable := false,
     npmPackageBinaries := Seq((npmPackageName.value, npmPackageOutputFilename.value)),
+    npmPackageType := {
+      if (scalaJSLinkerConfig.value.moduleKind == ModuleKind.ESModule) "module"
+      else "commonjs"
+    },
     npmPackageREADME := {
       val path = file("README.md")
       if (java.nio.file.Files.exists(path.toPath())) Option(path)
@@ -251,6 +258,7 @@ object NpmPackagePlugin extends AutoPlugin {
           npmPackageAdditionalNpmConfig.value,
           npmPackageBinaryEnable.value,
           npmPackageBinaries.value,
+          npmPackageType.value,
           dependencyClasspath.value,
           configuration.value,
           streams.value


### PR DESCRIPTION
Sets the ["type"](https://nodejs.org/api/packages.html#type) field. `"commonjs"` for `ModuleKind.CommonJSModule` and `"module"` for `ModuleKind.ESModule`. 

Technically, a breaking change for two reasons, but it is still a more sensible default to me:

1. The functions inside `PackageFile` now have an extra argument. I don't know whether this is considered public API or not. If it is, this is a breaking change.
2. Some users might depend on the 'default' Node behaviour, which is `"type": "commonjs"` even with `ModuleKind.ESModule`. It seems unlikely to me that anyone depends on it like that, but it is a breaking change
