### PR TITLE
tweak .npmrc output, with additional settings for customization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,8 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("test"))
 )
 
-val catsV = "2.6.1"
-val catsEffectV = "3.1.1"
-val fs2V = "3.0.6"
 val circeV = "0.14.1"
+val http4sV = "0.23.16"
 
 
 // Projects
@@ -44,8 +42,9 @@ lazy val core = project.in(file("core"))
     },
     addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion),
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core"   % circeV,
-      "io.circe" %% "circe-parser" % circeV,
+      "io.circe"   %% "circe-core"    % circeV,
+      "io.circe"   %% "circe-parser"  % circeV,
+      "org.http4s" %% "http4s-core"   % http4sV,
     )
   )
 

--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -179,7 +179,15 @@ object NpmPackagePlugin extends AutoPlugin {
     val npmPackageInstall = taskKey[File]("Install Deps for npm/yarn for the npm package")
     val npmPackagePublish = taskKey[File]("Publish for npm/yarn for the npm package")
     val npmPackageNpmrc = taskKey[File]("Write Npmrc File")
+    val npmPackageNpmrcAuthType = settingKey[AuthType]("what authentication method should npm use for authenticating with the registry")
 
+    sealed trait AuthType
+    case object Auth extends AuthType {
+      override def toString: String = "_auth"
+    }
+    case object AuthToken extends AuthType {
+      override def toString: String = "_authToken"
+    }
   }
   import autoImport._
 
@@ -216,6 +224,7 @@ object NpmPackagePlugin extends AutoPlugin {
     npmPackageNpmrcRegistry := None,
     npmPackageNpmrcScope := None,
     npmPackageNpmrcAuthEnvironmentalVariable := "NPM_TOKEN",
+    npmPackageNpmrcAuthType := AuthToken,
     npmPackageBinaryEnable := false,
     npmPackageREADME := {
       val path = file("README.md")
@@ -348,7 +357,8 @@ object NpmPackagePlugin extends AutoPlugin {
         npmPackageNpmrcScope.value,
         npmPackageNpmrcRegistry.value,
         npmPackageNpmrcAuthEnvironmentalVariable.value,
-        streams.value.log
+        streams.value.log,
+        npmPackageNpmrcAuthType.value
       )
     },
 

--- a/core/src/sbt-test/sbt-npm-package/minimal-example/customized-expected-npmrc
+++ b/core/src/sbt-test/sbt-npm-package/minimal-example/customized-expected-npmrc
@@ -1,0 +1,2 @@
+@custom-scope:registry=https://custom-registry.example.com/repository/npm-snapshots/
+//custom-registry.example.com/repository/npm-snapshots/:_auth=${NPM_TOKEN}

--- a/core/src/sbt-test/sbt-npm-package/minimal-example/default-expected-npmrc
+++ b/core/src/sbt-test/sbt-npm-package/minimal-example/default-expected-npmrc
@@ -1,0 +1,2 @@
+
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/core/src/sbt-test/sbt-npm-package/minimal-example/test
+++ b/core/src/sbt-test/sbt-npm-package/minimal-example/test
@@ -1,7 +1,8 @@
 > clean
 
 # Check Node Output
-> npmPackageNpmrc 
+> npmPackageNpmrc
+$ must-mirror default-expected-npmrc target/scala-2.12/npm-package/.npmrc
 > npmPackage
 $ exists target/scala-2.12/npm-package/main.js
 $ exists target/scala-2.12/npm-package/main.js.map
@@ -10,3 +11,10 @@ $ exec grep '//# sourceMappingURL=main.js.map' target/scala-2.12/npm-package/mai
 -$ exec grep '//# sourceMappingURL=minimal-example-fastopt.js.map' target/scala-2.12/npm-package/main.js
 # Check we can do it again
 > npmPackage
+
+# set custom registry and scope and check .npmrc
+> set npmPackageNpmrcAuthType := Auth
+> set npmPackageNpmrcScope := Option("custom-scope")
+> set npmPackageNpmrcRegistry := Option("https://custom-registry.example.com/repository/npm-snapshots/")
+> npmPackageNpmrc
+$ must-mirror customized-expected-npmrc target/scala-2.12/npm-package/.npmrc


### PR DESCRIPTION
This is an initial attempt to fix #28. I pulled http4s-core into scope to take advantage of its URI parsing (because the registry auth needs the registry URI with the scheme removed), but I'm definitely open to other ways to do this. 