### PR TITLE
Add Configuration for Private Publishing

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
+++ b/core/src/main/scala/io/chrisdavenport/npmpackage/sbtplugin/NpmPackagePlugin.scala
@@ -2,6 +2,7 @@ package io.chrisdavenport.npmpackage
 package sbtplugin
 
 
+import cats.syntax.all._
 import sbt._
 import Keys._
 import _root_.io.circe.Json
@@ -180,6 +181,8 @@ object NpmPackagePlugin extends AutoPlugin {
     val npmPackagePublish = taskKey[File]("Publish for npm/yarn for the npm package")
     val npmPackageNpmrc = taskKey[File]("Write Npmrc File")
 
+    val npmPackageNpmrcAdditionalScopes: SettingKey[Map[String, String]] = settingKey[Map[String, String]]("Additional Scopes to Set Resolution for in the .npmrc file")
+    val npmPackageNpmrcKeySettings: SettingKey[Seq[(String, String, String)]] = settingKey[Seq[(String, String, String)]]("Key Value Pairs to Set for specific paths")
   }
   import autoImport._
 
@@ -187,7 +190,16 @@ object NpmPackagePlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    npmPackageName := name.value,
+    npmPackageName := {
+      val s = npmPackageNpmrcScope.value.map("@" + _ + "/")
+      val n = name.value
+      s"${s.getOrElse("")}$n"
+    },
+    npmPackageAdditionalNpmConfig := {
+      npmPackageNpmrcRegistry.value.fold(Map[String, Json]())(s =>
+        Map("publishConfig" -> Json.obj("registry" -> Json.fromString(s)))
+      )
+    },
     npmPackageBinaries := Seq((npmPackageName.value, npmPackageOutputFilename.value)),
     npmPackageVersion := {
       val vn = VersionNumber(version.value)
@@ -206,7 +218,6 @@ object NpmPackagePlugin extends AutoPlugin {
     npmPackageDependencies := Seq(),
     npmPackageDevDependencies := Seq(),
     npmPackageResolutions := Map(),
-    npmPackageAdditionalNpmConfig := Map(),
     npmPackageOutputFilename := "main.js",
     npmPackageStage := Stage.FastOpt,
     npmPackageUseYarn := false,
@@ -222,6 +233,10 @@ object NpmPackagePlugin extends AutoPlugin {
       if (java.nio.file.Files.exists(path.toPath())) Option(path)
       else Option.empty[File]
     },
+    npmPackageNpmrcAdditionalScopes := Map.empty,
+    npmPackageNpmrcKeySettings := Seq(
+      ("//registry.npmjs.org/", "_authToken", npmPackageNpmrcAuthEnvironmentalVariable.value)
+    )
   )
 
   lazy val perConfigSettings = Def.settings(
@@ -343,11 +358,16 @@ object NpmPackagePlugin extends AutoPlugin {
     },
 
     npmPackageNpmrc := {
+      val ourScope = npmPackageNpmrcScope.value
+      val ourReg = npmPackageNpmrcRegistry.value
+      val ourScopes = (ourScope, ourReg).tupled.fold(List.empty[(String, String)])(_ :: Nil)
+      val registries = npmPackageNpmrcAdditionalScopes.value.toList ++ ourScopes
+      val keys = npmPackageNpmrcKeySettings.value
+
       NpmConfig.writeNpmrc(
         npmPackageOutputDirectory.value,
-        npmPackageNpmrcScope.value,
-        npmPackageNpmrcRegistry.value,
-        npmPackageNpmrcAuthEnvironmentalVariable.value,
+        registries,
+        keys.toList,
         streams.value.log
       )
     },


### PR DESCRIPTION
- Allows extension of credential keys for paths

```
npmPackageNpmrcKeySettings += ("//custom-repository.example.com/", "_auth", "value")
```

- Allows Definition of Custom Scopes for resolution

```
npmPackageNpmrcAdditionalScopes += "@myorg" -> "https://somewhere-else.com/myorg"
````

Should automatically infer what was inferred before but only add the line for the key, so the default key settings will set //registry.npmjs.org _authToken to the `npmPackageNpmrcAuthEnvironmentalVariable`, this is to keep consistent with how previous publication was working. 
